### PR TITLE
Proposed fix for RefOS compile issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ ifeq ($(ARCH),x86_64)
 $(error x86_64 not supported)
 endif
 
+ifeq ($(ARCH),x86)
+MARCH = ia32
+else
 MARCH = $(ARCH)
+endif
 
 ifdef CONFIG_X86_64
 	MARCH = x86_64


### PR DESCRIPTION
This PR is one of three. The PRs together should represent one possible way to fix the RefOS compile issue: seL4/refos-manifest#1

It involves the following 3 repos: refos-manifest, refos, libmuslc
